### PR TITLE
Make JUnzip more reusable as a library

### DIFF
--- a/junzip.c
+++ b/junzip.c
@@ -62,7 +62,7 @@ int jzReadEndRecord(JZFile *zip, JZEndRecord *endRecord) {
 
 // Read ZIP file global directory. Will move within file.
 int jzReadCentralDirectory(JZFile *zip, JZEndRecord *endRecord,
-        JZRecordCallback callback) {
+        JZRecordCallback callback, void *user_data) {
     JZGlobalFileHeader fileHeader;
     JZFileHeader header;
     int i;
@@ -107,7 +107,7 @@ int jzReadCentralDirectory(JZFile *zip, JZEndRecord *endRecord,
         memcpy(&header, &fileHeader.compressionMethod, sizeof(header));
         header.offset = fileHeader.relativeOffsetOflocalHeader;
 
-        if(!callback(zip, i, &header, (char *)jzBuffer))
+        if(!callback(zip, i, &header, (char *)jzBuffer, user_data))
             break; // end if callback returns zero
     }
 

--- a/junzip.c
+++ b/junzip.c
@@ -272,7 +272,7 @@ stdio_read_file_handle_close(JZFile *file)
 JZFile *
 jzfile_from_stdio_file(FILE *fp)
 {
-    StdioJZFile *handle = malloc(sizeof(StdioJZFile));
+    StdioJZFile *handle = (StdioJZFile *)malloc(sizeof(StdioJZFile));
 
     handle->handle.read = stdio_read_file_handle_read;
     handle->handle.tell = stdio_read_file_handle_tell;

--- a/junzip.h
+++ b/junzip.h
@@ -6,6 +6,10 @@
 #ifndef __JUNZIP_H
 #define __JUNZIP_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
 #include <stdint.h>
 
 // If you don't have stdint.h, the following two lines should work for most 32/64 bit systems
@@ -102,5 +106,9 @@ int jzReadLocalFileHeader(JZFile *zip, JZFileHeader *header,
 // Read data from file stream, described by header, to preallocated buffer
 // Return value is zlib coded, e.g. Z_OK, or error code
 int jzReadData(JZFile *zip, JZFileHeader *header, void *buffer);
+
+#ifdef __cplusplus
+};
+#endif /* __cplusplus */
 
 #endif

--- a/junzip.h
+++ b/junzip.h
@@ -83,7 +83,7 @@ typedef struct __attribute__ ((__packed__)) {
 
 // Callback prototype for central and local file record reading functions
 typedef int (*JZRecordCallback)(JZFile *zip, int index, JZFileHeader *header,
-        char *filename);
+        char *filename, void *user_data);
 
 #define JZ_BUFFER_SIZE 65536
 
@@ -93,7 +93,7 @@ int jzReadEndRecord(JZFile *zip, JZEndRecord *endRecord);
 // Read ZIP file global directory. Will move within file.
 // Callback is called for each record, until callback returns zero
 int jzReadCentralDirectory(JZFile *zip, JZEndRecord *endRecord,
-        JZRecordCallback callback);
+        JZRecordCallback callback, void *user_data);
 
 // Read local ZIP file header. Silent on errors so optimistic reading possible.
 int jzReadLocalFileHeader(JZFile *zip, JZFileHeader *header,

--- a/junzip.h
+++ b/junzip.h
@@ -12,6 +12,19 @@
 // typedef unsigned int uint32_t;
 // typedef unsigned short uint16_t;
 
+typedef struct JZFile JZFile;
+
+struct JZFile {
+    size_t (*read)(JZFile *file, void *buf, size_t size);
+    size_t (*tell)(JZFile *file);
+    int (*seek)(JZFile *file, size_t offset, int whence);
+    int (*error)(JZFile *file);
+    void (*close)(JZFile *file);
+};
+
+JZFile *
+jzfile_from_stdio_file(FILE *fp);
+
 typedef struct __attribute__ ((__packed__)) {
     uint32_t signature;
     uint16_t versionNeededToExtract; // unsupported
@@ -69,25 +82,25 @@ typedef struct __attribute__ ((__packed__)) {
 } JZEndRecord;
 
 // Callback prototype for central and local file record reading functions
-typedef int (*JZRecordCallback)(FILE *zip, int index, JZFileHeader *header,
+typedef int (*JZRecordCallback)(JZFile *zip, int index, JZFileHeader *header,
         char *filename);
 
 #define JZ_BUFFER_SIZE 65536
 
 // Read ZIP file end record. Will move within file.
-int jzReadEndRecord(FILE *zip, JZEndRecord *endRecord);
+int jzReadEndRecord(JZFile *zip, JZEndRecord *endRecord);
 
 // Read ZIP file global directory. Will move within file.
 // Callback is called for each record, until callback returns zero
-int jzReadCentralDirectory(FILE *zip, JZEndRecord *endRecord,
+int jzReadCentralDirectory(JZFile *zip, JZEndRecord *endRecord,
         JZRecordCallback callback);
 
 // Read local ZIP file header. Silent on errors so optimistic reading possible.
-int jzReadLocalFileHeader(FILE *zip, JZFileHeader *header,
+int jzReadLocalFileHeader(JZFile *zip, JZFileHeader *header,
         char *filename, int len);
 
 // Read data from file stream, described by header, to preallocated buffer
 // Return value is zlib coded, e.g. Z_OK, or error code
-int jzReadData(FILE *zip, JZFileHeader *header, void *buffer);
+int jzReadData(JZFile *zip, JZFileHeader *header, void *buffer);
 
 #endif

--- a/junzip_demo.c
+++ b/junzip_demo.c
@@ -80,7 +80,7 @@ int processFile(JZFile *zip) {
     return 0;
 }
 
-int recordCallback(JZFile *zip, int idx, JZFileHeader *header, char *filename) {
+int recordCallback(JZFile *zip, int idx, JZFileHeader *header, char *filename, void *user_data) {
     long offset;
 
     offset = zip->tell(zip); // store current position
@@ -121,7 +121,7 @@ int main(int argc, char *argv[]) {
         goto endClose;
     }
 
-    if(jzReadCentralDirectory(zip, &endRecord, recordCallback)) {
+    if(jzReadCentralDirectory(zip, &endRecord, recordCallback, NULL)) {
         printf("Couldn't read ZIP file central record.");
         goto endClose;
     }

--- a/junzip_demo.c
+++ b/junzip_demo.c
@@ -50,7 +50,7 @@ void writeFile(char *filename, void *data, long bytes) {
     }
 }
 
-int processFile(FILE *zip) {
+int processFile(JZFile *zip) {
     JZFileHeader header;
     char filename[1024];
     unsigned char *data;
@@ -80,37 +80,41 @@ int processFile(FILE *zip) {
     return 0;
 }
 
-int recordCallback(FILE *zip, int idx, JZFileHeader *header, char *filename) {
+int recordCallback(JZFile *zip, int idx, JZFileHeader *header, char *filename) {
     long offset;
 
-    offset = ftell(zip); // store current position
+    offset = zip->tell(zip); // store current position
 
-    if(fseek(zip, header->offset, SEEK_SET)) {
+    if(zip->seek(zip, header->offset, SEEK_SET)) {
         printf("Cannot seek in zip file!");
         return 0; // abort
     }
 
     processFile(zip); // alters file offset
 
-    fseek(zip, offset, SEEK_SET); // return to position
+    zip->seek(zip, offset, SEEK_SET); // return to position
 
     return 1; // continue
 }
 
 int main(int argc, char *argv[]) {
-    FILE *zip;
+    FILE *fp;
     int retval = -1;
     JZEndRecord endRecord;
+
+    JZFile *zip;
 
     if(argc < 2) {
         puts("Usage: junzip_demo file.zip");
         return -1;
     }
 
-    if(!(zip = fopen(argv[1], "rb"))) {
+    if(!(fp = fopen(argv[1], "rb"))) {
         printf("Couldn't open \"%s\"!", argv[1]);
         return -1;
     }
+
+    zip = jzfile_from_stdio_file(fp);
 
     if(jzReadEndRecord(zip, &endRecord)) {
         printf("Couldn't read ZIP file end record.");
@@ -128,7 +132,7 @@ int main(int argc, char *argv[]) {
     retval = 0;
 
 endClose:
-    fclose(zip);
+    zip->close(zip);
 
     return retval;
 }


### PR DESCRIPTION
These three changes make it easier to integrate the library into a C++ project:

 * File I/O abstraction, so one can read from other sources than stdio `FILE *` pointers
 * Do not require global state by making JSRecordCallback a closure (`void *user_data`)
 * Preprocessor directives for enabling inclusion of the library into C++ projects (`extern "C"`)